### PR TITLE
bayarea: set colors for extra calendar sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 backup
 sites/meta/hugo.toml
 sites/meta/assets/*.jpg
+*tmp*

--- a/sites/bayarea/hugo.toml
+++ b/sites/bayarea/hugo.toml
@@ -15,10 +15,10 @@ disableKinds = ["taxonomy", "term"]
   image = "profile.jpg"
   headline = 'Meta list of yo-yo clubs in Bay Area + miscellaneous non-club events.'
   calendarLink = "https://calendar.google.com/calendar/embed?src=bayareayoyoclub%40gmail.com&ctz=America%2FLos_Angeles"
-  extraCalendarSources = [
-    "spindoxyoyo%40gmail.com",
-    "sfyoyoclub%40gmail.com",
-    "eastbayyoyo%40gmail.com",
+  extraCalSources = [
+    { id = "spindoxyoyo@gmail.com", color = "#9e69af" },
+    { id = "sfyoyoclub@gmail.com", color = "#f76024" }, # sf giants orange hex code
+    { id = "eastbayyoyo@gmail.com", color = "#003831" }, # oakland a's green hex code
   ]
   links = [
     { spindox = { href = "https://spindox.yoyoclub.info", text = "Spindox (Peninsula)", icon = "link" } },

--- a/sites/meta/layouts/_shortcodes/gcalembed.html
+++ b/sites/meta/layouts/_shortcodes/gcalembed.html
@@ -1,24 +1,24 @@
-{{- if isset .Site.Params.Author "calendarlink" }}
-    {{- $calendarLink := or (.Site.Params.Author.calendarLink) ""}}
-    {{- if hasPrefix $calendarLink "https://calendar.google" }}
-        <span style="display: inline-block; visibility: hidden; height: 0; overflow: hidden">
-        The embedded iframe below won't expand to the full screen size of the device if there isn't any other content, so this is a long string to make sure there is plenty of width for the iframe to expand to on users devices.
-        </span>
-        {{- $calendarUrl := print .Site.Params.Author.calendarLink "&wkst=1&height=600&showPrint=0&mode=AGENDA&title&color=%23039be5" }}
-        {{- .Store.Set "calendarUrl" $calendarUrl }}
-        {{- if isset .Site.Params.Author "extracalendarsources" }}
-            {{- $extraSources := .Site.Params.Author.extraCalendarSources }}
-            {{- if gt (len $extraSources) 0 }}
-                {{- $calendarUrl := print $calendarUrl "&src=" (delimit $extraSources "&src=") }}
-                {{- .Store.Set "calendarUrl" $calendarUrl }}
-            {{- end }}
+{{- $calendarLink := or (.Site.Params.Author.calendarLink) ""}}
+{{- if hasPrefix $calendarLink "https://calendar.google" }}
+    <span style="display: inline-block; visibility: hidden; height: 0; overflow: hidden">
+    The embedded iframe below won't expand to the full screen size of the device if there isn't any other content, so this is a long string to make sure there is plenty of width for the iframe to expand to on users devices.
+    </span>
+    {{- $calendarUrl := print .Site.Params.Author.calendarLink "&wkst=1&height=600&showPrint=0&mode=AGENDA&title&color=%23039be5" }}
+    {{- site.Store.Set "calendarUrl" $calendarUrl }}
+    {{- if isset .Site.Params.Author "extracalsources" }}
+        {{- $extraSources := .Site.Params.Author.extraCalSources }}
+        {{- range $index, $src := $extraSources }}
+            {{- $calUrl := site.Store.Get "calendarUrl" }}
+            {{- $qs := collections.Querify (dict "src" $src.id "color" $src.color )}}
+            {{- $calUrl := print $calUrl "&" $qs }}
+            {{- site.Store.Set "calendarUrl" $calUrl }}
         {{- end }}
-        {{- $calendarUrl := .Store.Get "calendarUrl" }}
-        <details class="mb-4" >
-            <summary class="cursor-pointer text-lg font-semibold mb-2 dark:text-white">View upcoming events on the calendar (click to expand)</summary>
-            <div class="responsive-iframe-container">
-                <iframe src="{{ $calendarUrl }}" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
-            </div>
-        </details>
     {{- end }}
+    {{- $calendarUrl := site.Store.Get "calendarUrl" }}
+    <details class="mb-4" >
+        <summary class="cursor-pointer text-lg font-semibold mb-2 dark:text-white">View upcoming events on the calendar (click to expand)</summary>
+        <div class="responsive-iframe-container">
+            <iframe src="{{ $calendarUrl }}" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+        </div>
+    </details>
 {{- end }}


### PR DESCRIPTION
### changes

* ignore `*tmp*` files
* remove unnecessary `isset` check in `gcalembed` shortcode
* update `gcalembed` shortcode to support defining colors for the extra calendar sources
* update `bayarea` site to set colors for the extra calendar sources