### PR TITLE
fix: deprecated Site.Author access in theme

### DIFF
--- a/sites/meta/layouts/partials/footer.html
+++ b/sites/meta/layouts/partials/footer.html
@@ -1,0 +1,28 @@
+<footer class="py-10">
+  <div class="text-center">
+    {{/* Copyright */}}
+    <p class="text-sm text-neutral-500 dark:text-neutral-400">
+      {{- with .Site.Copyright }}
+        {{ . | emojify | markdownify }}
+      {{- else }}
+        &copy;
+        {{ now.Format "2006" }}
+        {{ .Site.Params.Author.name | markdownify | emojify }}
+      {{- end }}
+    </p>
+    {{/* Theme attribution */}}
+    {{ if .Site.Params.attribution | default true }}
+      <p class="text-xs text-neutral-500 dark:text-neutral-400">
+        {{ $hugo := printf `<a class="hover:underline hover:decoration-primary-400 hover:text-primary-500"
+          href="https://gohugo.io/" target="_blank" rel="noopener noreferrer">Hugo</a>`
+        }}
+        {{ $lynx := printf `<a class="hover:underline hover:decoration-primary-400 hover:text-primary-500" href="https://git.io/hugo-lynx" target="_blank" rel="noopener noreferrer">Lynx</a>` }}
+        {{ i18n "footer.powered_by" (dict "Hugo" $hugo "Lynx" $lynx) | safeHTML }}
+      </p>
+    {{ end }}
+  </div>
+  {{/* Extend footer - eg. for extra scripts, etc. */}}
+  {{ if templates.Exists "partials/extend-footer.html" }}
+    {{ partialCached "extend-footer.html" . }}
+  {{ end }}
+</footer>

--- a/sites/meta/layouts/partials/head.html
+++ b/sites/meta/layouts/partials/head.html
@@ -1,0 +1,92 @@
+<head>
+  <meta charset="utf-8" />
+  {{ with .Site.LanguageCode }}
+    <meta http-equiv="content-language" content="{{ . }}" />
+  {{ end }}
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+  {{/* Title */}}
+  {{ if .IsHome -}}
+    <title>{{ .Site.Title }}</title>
+    <meta name="title" content="{{ .Site.Title }}" />
+  {{- else -}}
+    <title>{{ .Title | emojify }} &middot; {{ .Site.Title | emojify }}</title>
+    <meta name="title" content="{{ .Title | emojify }} &middot; {{ .Site.Title | emojify }}" />
+  {{- end }}
+  {{/* Metadata */}}
+  {{ with .Params.Description -}}
+    <meta name="description" content="{{ . }}" />
+  {{- else -}}
+    <meta name="description" content="{{ $.Site.Params.Description }}" />
+  {{- end }}
+  {{ with .Site.Params.keywords -}}
+    <meta name="keywords" content="{{ . }}" />
+  {{- end }}
+  {{ with .Site.Params.robots }}
+    <meta name="robots" content="{{ . }}" />
+  {{ end }}
+  {{ with .Params.robots }}
+    <meta name="robots" content="{{ . }}" />
+  {{ end }}
+  <link rel="canonical" href="{{ .Permalink }}" />
+  {{ range .AlternativeOutputFormats -}}
+    {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .RelPermalink $.Site.Title | safeHTML }}
+  {{ end -}}
+  {{/* Asset bundles */}}
+  {{ $assets := newScratch }}
+  {{ $cssMain := resources.Get "css/compiled/main.css" }}
+  {{ $assets.Add "css" (slice $cssMain) }}
+  {{ $cssCustom := resources.Get "css/custom.css" }}
+  {{ if $cssCustom }}
+    {{ $assets.Add "css" (slice $cssCustom) }}
+  {{ end }}
+  {{ $bundleCSS := $assets.Get "css" | resources.Concat "css/main.bundle.css" | resources.Minify | resources.Fingerprint "sha512" }}
+  <link
+    type="text/css"
+    rel="stylesheet"
+    href="{{ $bundleCSS.RelPermalink }}"
+    integrity="{{ $bundleCSS.Data.Integrity }}"
+  />
+  {{/* Icons */}}
+  {{ if templates.Exists "partials/favicons.html" }}
+    {{ partialCached "favicons.html" .Site }}
+  {{ else }}
+    <link rel="apple-touch-icon" sizes="180x180" href="{{ "apple-touch-icon.png" | relURL }}" />
+    <link rel="icon" type="image/png" sizes="32x32" href="{{ "favicon-32x32.png" | relURL }}" />
+    <link rel="icon" type="image/png" sizes="16x16" href="{{ "favicon-16x16.png" | relURL }}" />
+    <link rel="manifest" href="{{ "site.webmanifest" | relURL }}" />
+  {{ end }}
+  {{/* Site Verification */}}
+  {{ with .Site.Params.verification.google }}
+    <meta name="google-site-verification" content="{{ . }}" />
+  {{ end }}
+  {{ with .Site.Params.verification.bing }}
+    <meta name="msvalidate.01" content="{{ . }}" />
+  {{ end }}
+  {{ with .Site.Params.verification.pinterest }}
+    <meta name="p:domain_verify" content="{{ . }}" />
+  {{ end }}
+  {{ with .Site.Params.verification.yandex }}
+    <meta name="yandex-verification" content="{{ . }}" />
+  {{ end }}
+  {{/* Social */}}
+  {{ template "_internal/opengraph.html" . }}
+  {{ template "_internal/twitter_cards.html" . }}
+  {{/* Generator */}}
+  {{ if .Site.Params.attribution | default true }}
+    {{ hugo.Generator }}
+  {{ end }}
+  {{/* Me */}}
+  {{ with .Site.Params.Author.name }}<meta name="author" content="{{ . }}" />{{ end }}
+  {{ with .Site.Params.Author.links }}
+    {{ range $links := . }}
+      {{ range $name, $url := $links }}<link href="{{ $url }}" rel="me" />{{ end }}
+    {{ end }}
+  {{ end }}
+  {{/* Analytics */}}
+  {{ partialCached "analytics.html" . }}
+  {{/* Extend head - eg. for custom analytics scripts, etc. */}}
+  {{ if templates.Exists "partials/extend-head.html" }}
+    {{ partialCached "extend-head.html" .Site }}
+  {{ end }}
+</head>


### PR DESCRIPTION
### changes

lynx theme access the Author section in the hugo.toml via the old method back when it was a top-level config method. caused build failures. Unfortunately the theme hasn't been updated in two+ years.

copies the files into our meta dir and fixes the offending lines.

### testing

generated a site successfully.